### PR TITLE
Remove unnecessary rax prefix from data bag setting names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ knife data bag create --secret-file <LOCATION/NAME OF SECRET FILE>  rackspace cl
 ```
 {
   "id": "cloud",
-  "raxusername": "<YOUR CLOUD SERVER USERNAME>",
-  "raxapikey": "<YOUR CLOUD SERVER API KEY>",
-  "raxregion": "<YOUR ACCOUNT REGION (us OR uk)>"
+  "username": "<YOUR CLOUD SERVER USERNAME>",
+  "apikey": "<YOUR CLOUD SERVER API KEY>",
+  "region": "<YOUR ACCOUNT REGION (us OR uk)>"
 }
 ```
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,9 +43,9 @@ if Chef::DataBag.list.keys.include?("rackspace") && data_bag("rackspace").includ
   raxcloud = Chef::EncryptedDataBagItem.load("rackspace","cloud")
 
   #Create variables for the Rackspace Cloud username and apikey
-  node['cloud_monitoring']['rackspace_username'] = raxcloud['raxusername']
-  node['cloud_monitoring']['rackspace_api_key'] = raxcloud['raxapikey']
-  node['cloud_monitoring']['rackspace_auth_region'] = raxcloud['raxregion'] || 'notset'
+  node['cloud_monitoring']['rackspace_username'] = raxcloud['username']
+  node['cloud_monitoring']['rackspace_api_key'] = raxcloud['apikey']
+  node['cloud_monitoring']['rackspace_auth_region'] = raxcloud['region'] || 'notset'
   node['cloud_monitoring']['rackspace_auth_region'] = node['cloud_monitoring']['rackspace_auth_region'].downcase
 
   if node['cloud_monitoring']['rackspace_auth_region'] == 'us'


### PR DESCRIPTION
`rax` prefix is unnecessary (and I hate it), because data bag is already called rackspace.

Note: This change is backward in-compatible so we should bump the major version.
