### PR TITLE
add monitoring endpoints

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,3 +29,4 @@ default['cloud_monitoring']['agent']['id'] = nil
 default['cloud_monitoring']['agent']['channel'] = nil
 default['cloud_monitoring']['agent']['version'] = 'latest'
 default['cloud_monitoring']['agent']['token'] = nil
+default['cloud_monitoring']['monitoring_endpoints'] = [] # This should be a list of strings like 'x.x.x.x:port'

--- a/templates/default/rackspace-monitoring-agent.erb
+++ b/templates/default/rackspace-monitoring-agent.erb
@@ -2,3 +2,6 @@
 monitoring_id <%= @monitoring_id %>
 <% end %>
 monitoring_token <%= @monitoring_token %>
+<% if not node['cloud_monitoring']['monitoring_endpoints'].empty? %>
+monitoring_endpoints <%= node['cloud_monitoring']['monitoring_endpoints'].join(",") %>
+<% end %>


### PR DESCRIPTION
Add the ability to add <code>monitoring_endpoints</code> to the configuration.

This is done by setting <code>node['cloud_monitoring']['monitoring_endpoints'] = ['ip1:port', 'ip2:port']</code>

Some more documentation should probably be added, but there didn't seem to be a good place in the README, so suggestions there would be nice.
