### PR TITLE
recipes: agent: add instead of removing the agent apt repo

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -6,7 +6,7 @@ cookbook_file "#{Chef::Config[:file_cache_path]}/signing-key.asc" do
 end
 
 apt_repository "cloud-monitoring" do
-  uri "http://unstable.packages.cloudmonitoring.rackspace.com/linux-x86_64-ubuntu-10.04"
+  uri "http://unstable.packages.cloudmonitoring.rackspace.com/ubuntu-10.04-x86_64"
   distribution "cloudmonitoring"
   components ["main"]
   key "signing-key.asc"

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -6,11 +6,11 @@ cookbook_file "#{Chef::Config[:file_cache_path]}/signing-key.asc" do
 end
 
 apt_repository "cloud-monitoring" do
-  uri "http://master.packages.cloudmonitoring.rackspace.com/linux-x86_64-ubuntu-10.04"
+  uri "http://unstable.packages.cloudmonitoring.rackspace.com/linux-x86_64-ubuntu-10.04"
   distribution "cloudmonitoring"
   components ["main"]
   key "signing-key.asc"
-  action :remove
+  action :add
 end
 
 # TODO: Enable once we set it up


### PR DESCRIPTION
This seems to be incorrect. We want to add the agent repo.
