### PR TITLE
Add basic gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+metadata.json


### PR DESCRIPTION
Older versions of knife and also littlechef generate a metadata.json
that should always be ignored. When using this as a submodule it makes
it look dirty when it's not.
