### PR TITLE
Consistent data bag key names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The inner workings of the library depend on [fog](https://github.com/fog/fog) wh
 client called [rackspace-monitoring-rb](https://github.com/racker/rackspace-monitoring-rb).  These are handled in the
 instantiation and use of the Cookbook.
 
-A Rackspace Cloud Hosting account is required to use this tool.  And a valid `username` and `api_key` are required to
+A Rackspace Cloud Hosting account is required to use this tool.  And a valid `rackspace_username` and `rackspace_api_key` are required to
 authenticate into your account.
 
 You can get one here [sign-up](https://cart.rackspace.com/cloud/?cp_id=cloud_monitoring).
@@ -49,8 +49,8 @@ knife data bag create --secret-file <LOCATION/NAME OF SECRET FILE>  rackspace cl
 ```
 {
   "id": "cloud",
-  "username": "<YOUR CLOUD SERVER USERNAME>",
-  "apikey": "<YOUR CLOUD SERVER API KEY>",
+  "rackspace_username": "<YOUR CLOUD SERVER USERNAME>",
+  "rackspace_api_key": "<YOUR CLOUD SERVER API KEY>",
   "region": "<YOUR ACCOUNT REGION (us OR uk)>"
 }
 ```
@@ -68,8 +68,8 @@ knife data bag create --secret-file <LOCATION/NAME OF SECRET FILE>  rackspace cl
 ```
 {
   "id": "cloud",
-  "username": "<YOUR CLOUD SERVER USERNAME>",
-  "apikey": "<YOUR CLOUD SERVER API KEY>",
+  "rackspace_username": "<YOUR CLOUD SERVER USERNAME>",
+  "rackspace_api_key": "<YOUR CLOUD SERVER API KEY>",
   "region": "<YOUR ACCOUNT REGION (us OR uk)>"
 }
 ```

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,6 +43,10 @@ begin
   raxcloud = Chef::EncryptedDataBagItem.load("rackspace","cloud")
 
   #Create variables for the Rackspace Cloud username and api key
+  if not raxcloud['rackspace_username'] or raxcloud['username'] or raxcloud['apikey'] or not raxcloud['rackspace_api_key']
+    Chef::Log.error "Data bag keys for cloudmonitoring cookbook were changed to be more consistent. Please use 'rackspace_username' instead of 'username' and 'rackspace_api_key' instead of 'apikey'."
+    raise Chef::Exceptions::InvalidDataBagItemID
+  end
   node['cloud_monitoring']['rackspace_username'] = raxcloud['rackspace_username']
   node['cloud_monitoring']['rackspace_api_key'] = raxcloud['rackspace_api_key']
   node['cloud_monitoring']['rackspace_auth_region'] = raxcloud['region'] || 'notset'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,9 +42,9 @@ begin
   # Access the Rackspace Cloud encrypted data_bag
   raxcloud = Chef::EncryptedDataBagItem.load("rackspace","cloud")
 
-  #Create variables for the Rackspace Cloud username and apikey
-  node['cloud_monitoring']['rackspace_username'] = raxcloud['username']
-  node['cloud_monitoring']['rackspace_api_key'] = raxcloud['apikey']
+  #Create variables for the Rackspace Cloud username and api key
+  node['cloud_monitoring']['rackspace_username'] = raxcloud['rackspace_username']
+  node['cloud_monitoring']['rackspace_api_key'] = raxcloud['rackspace_api_key']
   node['cloud_monitoring']['rackspace_auth_region'] = raxcloud['region'] || 'notset'
   node['cloud_monitoring']['rackspace_auth_region'] = node['cloud_monitoring']['rackspace_auth_region'].downcase
 


### PR DESCRIPTION
The data bag keys we were using were called <code>username</code> and <code>apikey</code> which was inconsistent with what we were using everywhere else, which was <code>rackspace_username</code> and <code>rackspace_api_key</code>

This pull request both fixes the keys to be more consistent, and gives an error and exits the chef run if the user is still using the old keys.
