### PR TITLE
add a definition that adds checks to machines

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,3 +30,5 @@ default['cloud_monitoring']['agent']['channel'] = nil
 default['cloud_monitoring']['agent']['version'] = 'latest'
 default['cloud_monitoring']['agent']['token'] = nil
 default['cloud_monitoring']['monitoring_endpoints'] = [] # This should be a list of strings like 'x.x.x.x:port'
+
+default['cloud_monitoring']['custom_check_dir'] = '/usr/lib/rackspace-monitoring/plugins/'

--- a/definitions/rackspace_monitoring_check.rb
+++ b/definitions/rackspace_monitoring_check.rb
@@ -1,0 +1,17 @@
+define :rackspace_monitoring_check, :template => "" do
+
+params['file'] ||= params['template']
+
+  template "#{node['cloudmonitoring']['custom_check_dir']}/#{params['file']}" do
+    source params['template']
+    owner "root"
+    group "root"
+    mode 0755
+    if params['cookbook']
+      cookbook params['cookbook']
+    end
+    variables(
+      :params => params
+    )
+  end
+end


### PR DESCRIPTION
It would be nice to have a definition to add checks to a machine.

Note that even after checks are added, they don't run until they are created and enabled in the monitoring api. I am unsure if this should be done in the cookbook, or left as an exercise to the user to do elsewhere (or add). Opinions welcome.
