### PR TITLE
Remove apt-ck depends

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,5 +6,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.3"
 
 depends "python"
-# TODO: Add correct apt / yum repo, etc. once available
-depends "apt-ck"
+


### PR DESCRIPTION
We don't use this cookbook anymore this just never got taken out when we
switched to the official production/testing repo.
