### PR TITLE
Use chef_gem resource

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,6 @@ begin
   # chef_gem doesn't exist prior to 0.10.9
   chef_gem "rackspace-monitoring" do
     version node['cloud_monitoring']['rackspace_monitoring_version']
-    options "--no-ri --no-rdoc"
     action :install
   end
 rescue NameError => e
@@ -41,7 +40,6 @@ rescue NameError => e
   end
   r = gem_package "rackspace-monitoring" do
     version node['cloud_monitoring']['rackspace_monitoring_version']
-    options "--no-ri --no-rdoc"
     action :nothing
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,15 +27,25 @@ when "redhat","centos","fedora", "amazon","scientific"
   package( "libxml2-devel" ).run_action( :install )
 end
 
-r = gem_package "rackspace-monitoring" do
-  version node['cloud_monitoring']['rackspace_monitoring_version']
-  action :nothing
+begin
+  # chef_gem doesn't exist prior to 0.10.9
+  chef_gem "rackspace-monitoring" do
+    version node['cloud_monitoring']['rackspace_monitoring_version']
+    action :install
+  end
+rescue NameError => e
+  Chef::Log.warn "chef_gem resource doesn't exist, falling back to system ruby install"
+  r = gem_package "rackspace-monitoring" do
+    version node['cloud_monitoring']['rackspace_monitoring_version']
+    action :nothing
+  end
+
+  r.run_action(:install)
+
+  require 'rubygems'
+  Gem.clear_paths
 end
 
-r.run_action(:install)
-
-require 'rubygems'
-Gem.clear_paths
 require 'rackspace-monitoring'
 
 begin

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,6 @@ case node['platform']
 when "ubuntu","debian"
   package( "libxslt-dev" ).run_action( :install )
   package( "libxml2-dev" ).run_action( :install )
-  package( "ruby-dev" ).run_action( :install )
 when "redhat","centos","fedora", "amazon","scientific"
   package( "libxslt-devel" ).run_action( :install )
   package( "libxml2-devel" ).run_action( :install )
@@ -35,6 +34,10 @@ begin
   end
 rescue NameError => e
   Chef::Log.warn "chef_gem resource doesn't exist, falling back to system ruby install"
+
+  if node['platform_family'] == 'debian'
+    package( "ruby-dev" ).run_action( :install )
+  end
   r = gem_package "rackspace-monitoring" do
     version node['cloud_monitoring']['rackspace_monitoring_version']
     action :nothing

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ begin
   # chef_gem doesn't exist prior to 0.10.9
   chef_gem "rackspace-monitoring" do
     version node['cloud_monitoring']['rackspace_monitoring_version']
+    options "--no-ri --no-rdoc"
     action :install
   end
 rescue NameError => e
@@ -40,6 +41,7 @@ rescue NameError => e
   end
   r = gem_package "rackspace-monitoring" do
     version node['cloud_monitoring']['rackspace_monitoring_version']
+    options "--no-ri --no-rdoc"
     action :nothing
   end
 


### PR DESCRIPTION
The chef_gem resource was added in 0.10.9 to handle both omnibus
installs and to handle the common pattern of needing a gem within the
same Chef run.

Should be rebased once #15 is merged.
