### PR TITLE
Bump rackspace-monitoring gem version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-default['cloud_monitoring']['rackspace_monitoring_version'] = '0.2.13'
+default['cloud_monitoring']['rackspace_monitoring_version'] = '0.2.14'
 default['cloud_monitoring']['checks'] = {}
 default['cloud_monitoring']['alarms'] = {}
 default['cloud_monitoring']['rackspace_username'] = 'your_rackspace_username'


### PR DESCRIPTION
0.2.14 is the latest and works, no reason not to bump that I can see
