### PR TITLE
Add logging to providers

### DIFF
--- a/providers/agent_token.rb
+++ b/providers/agent_token.rb
@@ -3,10 +3,12 @@ include Rackspace::CloudMonitoring
 action :create do
   agent_token = cm.agent_tokens.new(:label => new_resource.label)
   if @current_resource.nil? then
+    Chef::Log.info("Creating #{new_resource}")
     agent_token.save
     new_resource.updated_by_last_action(true)
     clear_tokens
   else
+    Chef::Log.debug("#{new_resource} exists, skipping create")
     new_resource.updated_by_last_action(false)
   end
 end
@@ -14,10 +16,12 @@ end
 
 action :delete do
   if !@current_resource.nil? then
+    Chef::Log.info("Deleting #{new_resource}")
     @current_resource.destroy
     new_resource.updated_by_last_action(true)
     clear_tokens
   else
+    Chef::Log.debug("#{new_resource} doesn't exist, skipping delete")
     new_resource.updated_by_last_action(false)
   end
 end

--- a/providers/alarm.rb
+++ b/providers/alarm.rb
@@ -20,6 +20,7 @@ action :create do
                              :metadata => new_resource.metadata, :criteria => criteria,
                              :notification_plan_id => new_resource.notification_plan_id)
   if @current_resource.nil? then
+    Chef::Log.info("Creating #{new_resource}")
     check.save
     new_resource.updated_by_last_action(true)
     clear
@@ -27,11 +28,13 @@ action :create do
     # Compare attributes
     if !check.compare? @current_resource then
       # It's different issue and update
+      Chef::Log.info("Updating #{new_resource}")
       check.id = @current_resource.id
       check.save
       new_resource.updated_by_last_action(true)
       clear
     else
+      Chef::Log.debug("#{new_resource} matches, skipping")
       new_resource.updated_by_last_action(false)
     end
   end

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -7,6 +7,7 @@ action :create do
                              :target_resolver => new_resource.target_resolver, :timeout => new_resource.timeout,
                              :period => new_resource.period)
   if @current_resource.nil? then
+    Chef::Log.info("Creating #{new_resource}")
     check.save
     new_resource.updated_by_last_action(true)
     clear
@@ -14,11 +15,13 @@ action :create do
     # Compare attributes
     if !check.compare? @current_resource then
       # It's different issue and update
+      Chef::Log.info("Updating #{new_resource}")
       check.id = @current_resource.id
       check.save
       new_resource.updated_by_last_action(true)
       clear
     else
+      Chef::Log.debug("#{new_resource} matches, skipping")
       new_resource.updated_by_last_action(false)
     end
   end

--- a/providers/entity.rb
+++ b/providers/entity.rb
@@ -12,6 +12,7 @@ action :create do
   entity = cm.entities.new(:label => new_resource.label, :ip_addresses => new_resource.ip_addresses,
                            :metadata => new_resource.metadata, :agent_id => new_resource.agent_id)
   if @current_resource.nil? then
+    Chef::Log.info("Creating #{new_resource}")
     entity.save
     new_resource.updated_by_last_action(true)
     clear
@@ -19,11 +20,13 @@ action :create do
     # Compare attributes
     if !entity.compare? @current_resource then
       # It's different
+      Chef::Log.info("Updating #{new_resource}")
       entity.id = @current_resource.id
       entity.save
       new_resource.updated_by_last_action(true)
       clear
     else
+      Chef::Log.debug("#{new_resource} matches, skipping")
       new_resource.updated_by_last_action(false)
     end
   end


### PR DESCRIPTION
This makes it easier to see what resources were created, modified, or
skipped during a run.

Looks like this:

```
INFO: Updating cloud_monitoring_check[check_updates]
```
