### PR TITLE
Add criteria DSL

### DIFF
--- a/libraries/monitoringcriteria.rb
+++ b/libraries/monitoringcriteria.rb
@@ -1,0 +1,58 @@
+
+begin
+  require "docile"
+rescue LoadError
+  Chef::Log.warn("Missing gem 'docile'")
+end
+
+module Rackspace
+  module CloudMonitoring
+    class MonitoringCriteria
+      attr_accessor :alerts
+      def initialize
+        @alerts = []
+      end
+      def warn_if(*args)
+        alert_if("WARNING", args)
+      end
+      def critical_if(*args)
+        alert_if("CRITICAL", args)
+      end
+      def ok(msg)
+        @alerts << return_message("OK", msg)
+      end
+      def to_s
+        @alerts.join("\n")
+      end
+
+      private
+      def alert_if(level, args)
+        @alerts << create(
+          args[0],
+          args[1],
+          args[2],
+          return_message(level, args[3])
+          )
+      end
+      def return_message(level, msg)
+        "return new AlarmStatus(#{level}, '#{msg}');"
+      end
+      def create(left_value, test_method, right_value, return_status)
+        test_methods = [">", "<", ">=", "<=", "==", "!="]
+        unless test_methods.include?(test_method)
+          raise "comparator must be one of #{test_methods.join(", ")}"
+        end
+        msg = "if (#{left_value} #{test_method} #{right_value}) {\n\t"
+        msg += return_status
+        msg += "\n}"
+        msg
+      end
+      def percentage(first, second)
+        "percentage(metric['#{first}'], metric['#{second}'])"
+      end
+      def metric(name)
+        "metric['#{name}']"
+      end
+    end
+  end
+end

--- a/providers/alarm.rb
+++ b/providers/alarm.rb
@@ -2,6 +2,7 @@ include Rackspace::CloudMonitoring
 
 action :create do
   criteria = new_resource.criteria
+  Chef::Log.debug("Setting #{new_resource} criteria:\n#{criteria}")
   check_id = new_resource.check_id
 
   if new_resource.example_id then

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,9 @@ begin
     version node['cloud_monitoring']['rackspace_monitoring_version']
     action :install
   end
+  chef_gem "docile" do
+    action :install
+  end
 rescue NameError => e
   Chef::Log.warn "chef_gem resource doesn't exist, falling back to system ruby install"
 
@@ -42,7 +45,11 @@ rescue NameError => e
     version node['cloud_monitoring']['rackspace_monitoring_version']
     action :nothing
   end
+  rr = gem_package "docile" do
+    action :nothing
+  end
 
+  rr.run_action(:install)
   r.run_action(:install)
 
   require 'rubygems'

--- a/resources/alarm.rb
+++ b/resources/alarm.rb
@@ -4,7 +4,6 @@ attribute :label, :kind_of => String, :name_attribute => true
 attribute :check_type, :kind_of => String
 attribute :check_id, :kind_of => String
 attribute :metadata, :kind_of => Hash
-attribute :criteria, :kind_of => String
 attribute :notification_plan_id, :kind_of => String, :required => true
 attribute :entity_id, :kind_of => String
 
@@ -15,3 +14,18 @@ attribute :check_label, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+
+def criteria(crit=nil, &block)
+  # This gets run twice for a resource and the second time everything is nil
+  # Therefore we check for the block and set that
+  if block_given?
+    require 'docile'
+    @criteria = Docile.dsl_eval(Rackspace::CloudMonitoring::MonitoringCriteria.new, &block).to_s
+  # Or we just leave it assigned
+  elsif @criteria
+    @criteria
+  # Or we assign it to whatever crit is
+  else
+    @criteria = crit
+  end
+end


### PR DESCRIPTION
I got tired of writing huge <<-EOF blocks for the alarm criteria's so I did this crazy thing. Seems like it might be a bad idea but I was shocked it actually works.

Still needs docs but it basically ends up working something like this:

``` ruby
cloud_monitoring_alarm "memory_usage alarm" do
  check_label "memory"
  criteria do
    critical_if(percentage("actual_used", "total"), ">", 95,
      "Memory usage is above 95%"
    )
    warn_if(percentage("actual_used", "total"), ">", 90,
      "Memory usage is above 90%"
    )
    ok "Memory usage is below 90"
  end
  notification_plan_id npid
  action :create
end
```

or you can still use strings if you want:

``` ruby
cloud_monitoring_alarm "ping alarm" do
  check_label "ping"
  criteria "if (metric['available'] < 100) { return CRITICAL, 'ping check packet loss'}"
  notification_plan_id npid
  action :create
end
```
