### PR TITLE
Make credentials configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,3 +36,7 @@ default['cloud_monitoring']['plugin_path'] = '/usr/lib/rackspace-monitoring-agen
 # plugins directory always gets included in the list of plugins and won't get overwriten by
 # a role or node attribute.
 default['cloud_monitoring']['plugins']['cloud_monitoring'] = 'plugins'
+
+default['cloud_monitoring']['credentials']['databag_name'] = 'rackspace'
+default['cloud_monitoring']['credentials']['databag_item'] = 'cloud'
+

--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -10,7 +10,10 @@ module Rackspace
     def cm
       begin
         # Access the Rackspace Cloud encrypted data_bag
-        creds = Chef::EncryptedDataBagItem.load("rackspace", "cloud")
+        databag_dir = node["cloud_monitoring"]["credentials"]["dir"] || "rackspace"
+        databag_filename = node["cloud_monitoring"]["credentials"]["filename"] || "cloud"
+
+        creds = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
       rescue Exception => e
         creds = {'username' => nil, 'apikey' => nil, 'auth_url' => nil }
       end

--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -10,8 +10,8 @@ module Rackspace
     def cm
       begin
         # Access the Rackspace Cloud encrypted data_bag
-        databag_dir = node["cloud_monitoring"]["credentials"]["dir"] || "rackspace"
-        databag_filename = node["cloud_monitoring"]["credentials"]["filename"] || "cloud"
+        databag_dir = node["cloud_monitoring"]["credentials"]["databag_name"]
+        databag_filename = node["cloud_monitoring"]["credentials"]["databag_item"]
 
         creds = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
       rescue Exception => e

--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -17,7 +17,7 @@ module Rackspace
 
       apikey = new_resource.rackspace_api_key || creds['apikey']
       username = new_resource.rackspace_username || creds['username']
-      auth_url = new_resource.rackspace_username || creds['auth_url']
+      auth_url = new_resource.rackspace_auth_url || creds['auth_url']
       @@cm ||= Fog::Monitoring::Rackspace.new(:rackspace_api_key => apikey, :rackspace_username => username,
                                               :rackspace_auth_url => auth_url,
                                               :raise_errors => node['cloud_monitoring']['abort_on_failure'])

--- a/providers/alarm.rb
+++ b/providers/alarm.rb
@@ -16,14 +16,9 @@ action :create do
     check_id = get_check_by_label(@entity.id, new_resource.check_label).identity
   end
 
-  notification_plan_id = new_resource.notification_plan_id || node['cloud_monitoring']['notification_plan_id']
-  if notification_plan_id.nil? then
-    raise ValueError, "Must specify 'notification_plan_id' in alarm resource or in node['cloud_monitoring']['notification_plan_id']"
-  end
-
   check = @entity.alarms.new(:label => new_resource.label, :check_type => new_resource.check_type, :check_id => check_id,
                              :metadata => new_resource.metadata, :criteria => criteria,
-                             :notification_plan_id => notification_plan_id)
+                             :notification_plan_id => new_resource.notification_plan_id)
   if @current_resource.nil? then
     Chef::Log.info("Creating #{new_resource}")
     check.save

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -23,7 +23,10 @@ end
 #end
 
 begin
-  values = Chef::EncryptedDataBagItem.load('rackspace', 'cloud')
+  databag_dir = node["cloud_monitoring"]["credentials"]["dir"] || "rackspace"
+  databag_filename = node["cloud_monitoring"]["credentials"]["filename"] || "cloud"
+
+  values = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
 
   node.set['cloud_monitoring']['agent']['token'] = values['agent_token'] || nil
 rescue Exception => e

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -23,8 +23,8 @@ end
 #end
 
 begin
-  databag_dir = node["cloud_monitoring"]["credentials"]["dir"] || "rackspace"
-  databag_filename = node["cloud_monitoring"]["credentials"]["filename"] || "cloud"
+  databag_dir = node["cloud_monitoring"]["credentials"]["databag_name"]
+  databag_filename = node["cloud_monitoring"]["credentials"]["databag_item"]
 
   values = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,8 +33,8 @@ begin
     version node['cloud_monitoring']['rackspace_monitoring_version']
     action :install
   end
-rescue
-  Chef::Log.warn "Error using chef_gem, falling back to system ruby install"
+rescue NameError => e
+  Chef::Log.warn "chef_gem resource doesn't exist, falling back to system ruby install"
 
   if node['platform_family'] == 'debian'
     package( "ruby-dev" ).run_action( :install )

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,7 +54,10 @@ require 'rackspace-monitoring'
 
 begin
   # Access the Rackspace Cloud encrypted data_bag
-  raxcloud = Chef::EncryptedDataBagItem.load("rackspace","cloud")
+  databag_dir = node["cloud_monitoring"]["credentials"]["dir"] || "rackspace"
+  databag_filename = node["cloud_monitoring"]["credentials"]["filename"] || "cloud"
+
+  raxcloud = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
 
   #Create variables for the Rackspace Cloud username and apikey
   node.set['cloud_monitoring']['rackspace_username'] = raxcloud['username']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,8 +54,8 @@ require 'rackspace-monitoring'
 
 begin
   # Access the Rackspace Cloud encrypted data_bag
-  databag_dir = node["cloud_monitoring"]["credentials"]["dir"] || "rackspace"
-  databag_filename = node["cloud_monitoring"]["credentials"]["filename"] || "cloud"
+  databag_dir = node["cloud_monitoring"]["credentials"]["databag_name"]
+  databag_filename = node["cloud_monitoring"]["credentials"]["databag_item"]
 
   raxcloud = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,8 +33,8 @@ begin
     version node['cloud_monitoring']['rackspace_monitoring_version']
     action :install
   end
-rescue NameError => e
-  Chef::Log.warn "chef_gem resource doesn't exist, falling back to system ruby install"
+rescue
+  Chef::Log.warn "Error using chef_gem, falling back to system ruby install"
 
   if node['platform_family'] == 'debian'
     package( "ruby-dev" ).run_action( :install )

--- a/resources/alarm.rb
+++ b/resources/alarm.rb
@@ -5,7 +5,7 @@ attribute :check_type, :kind_of => String
 attribute :check_id, :kind_of => String
 attribute :metadata, :kind_of => Hash
 attribute :criteria, :kind_of => String
-attribute :notification_plan_id, :kind_of => String
+attribute :notification_plan_id, :kind_of => String, :required => true
 attribute :entity_id, :kind_of => String
 attribute :entity_label, :kind_of => String
 
@@ -16,3 +16,4 @@ attribute :check_label, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -14,6 +14,6 @@ attribute :monitoring_zones_poll, :kind_of => Array
 attribute :entity_id, :kind_of => String
 attribute :entity_label, :kind_of => String
 
-
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String

--- a/resources/entity.rb
+++ b/resources/entity.rb
@@ -8,3 +8,4 @@ attribute :agent_id, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String


### PR DESCRIPTION
- Anywhere the encrypted databag was used now has a configurable node attribute to find the data bag. Will fallback to the old default if not specified.
- Make the chef gem system install an optional flag that users conciously choose to turn on
- Added missing auth url to the lwr for entity
