### PR TITLE
Alarms default to node['cloud_monitoring']['notification_plan_id']

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "daniel.dispaltro@rackspace.com"
 license          "Apache 2.0"
 description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.2.1"
 
 depends "python"
 

--- a/providers/alarm.rb
+++ b/providers/alarm.rb
@@ -16,9 +16,11 @@ action :create do
     check_id = get_check_by_label(@entity.id, new_resource.check_label).identity
   end
 
+  notification_plan_id = new_resource.notification_plan_id || node['cloud_monitoring']['notification_plan_id']
+
   check = @entity.alarms.new(:label => new_resource.label, :check_type => new_resource.check_type, :check_id => check_id,
                              :metadata => new_resource.metadata, :criteria => criteria,
-                             :notification_plan_id => new_resource.notification_plan_id)
+                             :notification_plan_id => notification_plan_id)
   if @current_resource.nil? then
     Chef::Log.info("Creating #{new_resource}")
     check.save

--- a/providers/alarm.rb
+++ b/providers/alarm.rb
@@ -17,6 +17,9 @@ action :create do
   end
 
   notification_plan_id = new_resource.notification_plan_id || node['cloud_monitoring']['notification_plan_id']
+  if notification_plan_id.nil? then
+    raise ValueError, "Must specify 'notification_plan_id' in alarm resource or in node['cloud_monitoring']['notification_plan_id']"
+  end
 
   check = @entity.alarms.new(:label => new_resource.label, :check_type => new_resource.check_type, :check_id => check_id,
                              :metadata => new_resource.metadata, :criteria => criteria,

--- a/resources/alarm.rb
+++ b/resources/alarm.rb
@@ -5,7 +5,7 @@ attribute :check_type, :kind_of => String
 attribute :check_id, :kind_of => String
 attribute :metadata, :kind_of => Hash
 attribute :criteria, :kind_of => String
-attribute :notification_plan_id, :kind_of => String, :required => true
+attribute :notification_plan_id, :kind_of => String
 attribute :entity_id, :kind_of => String
 
 attribute :example_id, :kind_of => String


### PR DESCRIPTION
We got tired of putting this everywhere and figured this was a
sensible default.
