### PR TITLE
Allow checks to specify entity_label attributes.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "daniel.dispaltro@rackspace.com"
 license          "Apache 2.0"
 description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.1"
+version          "0.2.2"
 
 depends "python"
 

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -29,7 +29,13 @@ end
 
 
 def load_current_resource
-  @entity = get_entity_by_id @new_resource.entity_id || node['cloud_monitoring']['entity_id']
+  if @new_resource.entity_label then
+    raise Exception, "Cannot specify entity_label and entity_id" unless @new_resource.entity_id.nil?
+    @entity = get_entity_by_label @new_resource.entity_label
+  else
+    @entity = get_entity_by_id @new_resource.entity_id || node['cloud_monitoring']['entity_id']
+  end
+
   @current_resource = get_check_by_id @entity.id, node['cloud_monitoring']['checks'][@new_resource.label]
   if @current_resource == nil then
     @current_resource = get_check_by_label @entity.id, @new_resource.label

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -12,6 +12,7 @@ attribute :timeout, :kind_of => Integer
 attribute :disabled, :kind_of => [TrueClass, FalseClass]
 attribute :monitoring_zones_poll, :kind_of => Array
 attribute :entity_id, :kind_of => String
+attribute :entity_label, :kind_of => String
 
 
 attribute :rackspace_api_key, :kind_of => String


### PR DESCRIPTION
This allows checks to unambiguously refer to an
entity (similar to how alarms unambiguously refer
to their associated checks).
