### PR TITLE
Add build-essential package for Debian/Ubuntu

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "daniel.dispaltro@rackspace.com"
 license          "Apache 2.0"
 description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.3"
+version          "0.2.4"
 
 depends "python"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@ case node['platform']
 when "ubuntu","debian"
   package( "libxslt-dev" ).run_action( :install )
   package( "libxml2-dev" ).run_action( :install )
+  package( "build-essential" ).run_action( :install )
 when "redhat","centos","fedora", "amazon","scientific"
   package( "libxslt-devel" ).run_action( :install )
   package( "libxml2-devel" ).run_action( :install )


### PR DESCRIPTION
rackspace-monitoring depends on rackspace-fog which depends on fog which
depends on nokogiri. Nokogiri needs a working build system to install.

I'm not sure and couldn't find reliable info on what the Redhat/CentOS
equivalent would be so I haven't added that.
