### PR TITLE
fix(agent): Dont opportunistically upgrade the agent by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,4 +37,3 @@ default['cloud_monitoring']['plugin_path'] = '/usr/lib/rackspace-monitoring-agen
 # plugins directory always gets included in the list of plugins and won't get overwriten by
 # a role or node attribute.
 default['cloud_monitoring']['plugins']['cloud_monitoring'] = 'plugins'
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['cloud_monitoring']['agent']['id'] = nil
 default['cloud_monitoring']['agent']['channel'] = nil
 default['cloud_monitoring']['agent']['version'] = 'latest'
 default['cloud_monitoring']['agent']['token'] = nil
+default['cloud_monitoring']['agent']['upgrade_via_distro'] = False
 default['cloud_monitoring']['monitoring_endpoints'] = [] # This should be a list of strings like 'x.x.x.x:port'
 
 default['cloud_monitoring']['plugin_path'] = '/usr/lib/rackspace-monitoring-agent/plugins'
@@ -36,3 +37,4 @@ default['cloud_monitoring']['plugin_path'] = '/usr/lib/rackspace-monitoring-agen
 # plugins directory always gets included in the list of plugins and won't get overwriten by
 # a role or node attribute.
 default['cloud_monitoring']['plugins']['cloud_monitoring'] = 'plugins'
+

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -34,14 +34,21 @@ if not node['cloud_monitoring']['agent']['token']
   raise RuntimeError, "agent_token variable must be set on the node."
 end
 
+# Don't install a newer version if upgrade_via_distro is False
+# The agent will autoupdate itself if installed at all so this is preferred
+# To force installing a specific version or "latest" set this to True and
+# indicate desired version in node['cloud_monitoring']['agent']['version']
 package "rackspace-monitoring-agent" do
-  if node['cloud_monitoring']['agent']['version'] == 'latest'
-    action :upgrade
+  if node['cloud_monitoring']['agent']['upgrade_via_distro']
+    if node['cloud_monitoring']['agent']['version'] == 'latest'
+      action :upgrade
+    else
+      version node['cloud_monitoring']['agent']['version']
+      action :install
+    end
   else
-    version node['cloud_monitoring']['agent']['version']
     action :install
   end
-
   notifies :restart, "service[rackspace-monitoring-agent]"
 end
 


### PR DESCRIPTION
The agent autoupdates when a new version is available, so there's no reason to default to installing the latest here. Also much less expensive to only install it once vs. looking to upgrade every chef run.
