### PR TITLE
Bump rackspace-monitoring library to 0.2.18

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-default['cloud_monitoring']['rackspace_monitoring_version'] = '0.2.14'
+default['cloud_monitoring']['rackspace_monitoring_version'] = '0.2.18'
 default['cloud_monitoring']['checks'] = {}
 default['cloud_monitoring']['alarms'] = {}
 default['cloud_monitoring']['rackspace_username'] = 'your_rackspace_username'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "daniel.dispaltro@rackspace.com"
 license          "Apache 2.0"
 description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.4"
+version          "0.2.5"
 
 depends "python"
 


### PR DESCRIPTION
ran into some issues with our servers that had over 100 entities on them, this pulls in a version of rackspace-monitoring with a fix
