### PR TITLE
Added fix for stale apt-cache

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             "cloudmonitoring"
+name             "cloud_monitoring"
 maintainer       "Rackspace"
 maintainer_email "daniel.dispaltro@rackspace.com"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "cloudmonitoring"
 maintainer       "Rackspace"
 maintainer_email "daniel.dispaltro@rackspace.com"
 license          "Apache 2.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,15 @@
 
 case node['platform']
 when "ubuntu","debian"
+
+  apt = execute "apt-get update" do
+    action :nothing
+  end
+
+  if File.mtime('/var/lib/apt/periodic/update-success-stamp') < Time.now - 86400
+    apt.run_action(:run)
+  end
+
   package( "libxslt-dev" ).run_action( :install )
   package( "libxml2-dev" ).run_action( :install )
   package( "build-essential" ).run_action( :install )


### PR DESCRIPTION
Since chef_gem and the package installs are running at compile time, they will fire off before the 'apt' cookbook, leaving no clean way to make sure the apt-cache is up to date. To fix issues with the stale apt-cache on our Ubuntu public cloud servers causing failures I added a check for a 24+ hour old apt-cache and an 'apt-get update' on ubuntu servers.
