### PR TITLE
Fixed DNS lookup issue when creating an entity

### DIFF
--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -17,7 +17,7 @@ module Rackspace
 
       apikey = new_resource.rackspace_api_key || creds['apikey']
       username = new_resource.rackspace_username || creds['username']
-      auth_url = new_resource.rackspace_username || creds['auth_url']
+      auth_url = new_resource.rackspace_auth_url || creds['auth_url']
       @@cm ||= Fog::Monitoring::Rackspace.new(:rackspace_api_key => apikey, :rackspace_username => username,
                                               :rackspace_auth_url => auth_url,
                                               :raise_errors => node['cloud_monitoring']['abort_on_failure'])

--- a/resources/entity.rb
+++ b/resources/entity.rb
@@ -8,3 +8,4 @@ attribute :agent_id, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String


### PR DESCRIPTION
Since auth_url was being filled with rackspace_username authentication was failing with 'error: Excon::Errors::SocketError: getaddrinfo: Name or service not known'

Added a rackspace_auth_url string and used it to fill auth_url
