### PR TITLE
Fixed agent_token to run before template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Specifically this recipe will focus on main atom's in the system.
 * Entities
 * Checks
 * Alarms
-* Agents (soon)
-* Agent Tokens (soon)
+* Agents (Ubuntu only currently)
+* Agent Tokens
 
 The cookbook also installs the python-pip package in Debian and RedHat based systems, and then uses pip to install the Rackspace Cloud Monitoring client, raxmon-cli, via pip
 
@@ -285,6 +285,16 @@ cloud_monitoring_alarm  "ping alarm" do
   action                :create
 end
 ```
+
+# Agent and Agent Tokens
+The Agent recipe will install the cloud monitoring agent on your node and either register it with a provided agent_token
+or if none is provided it will call the cloud_monitoring_agent_token provider to generate a new one for this node.
+
+The Agent token can either be provided through the following attribute.
+node['cloud_monitoring']['agent']['token']
+or through an entry in the rackspace cloud data bag like so.
+"token": "<Your Agent Token>"
+
 
 ## Agent Plugins
 

--- a/providers/agent_token.rb
+++ b/providers/agent_token.rb
@@ -32,5 +32,6 @@ def load_current_resource
   if @current_resource == nil then
     @current_resource = get_token_by_label @new_resource.label
     node.set['cloud_monitoring']['agent']['token'] = @current_resource.identity unless @current_resource.nil?
+    node.set['cloud_monitoring']['agent']['id'] = @current_resource.label unless @current_resource.nil?
   end
 end

--- a/providers/entity.rb
+++ b/providers/entity.rb
@@ -48,5 +48,6 @@ def load_current_resource
   if @current_resource == nil then
     @current_resource = get_entity_by_label @new_resource.label
     node.set['cloud_monitoring']['entity_id'] = @current_resource.identity unless @current_resource.nil?
+    node.set['cloud_monitoring']['agent']['id'] = @current_resource.label unless @current_resource.nil?
   end
 end

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -36,13 +36,21 @@ rescue Exception => e
 end
 
 if not node['cloud_monitoring']['agent']['token']
-  cloud_monitoring_agent_token "#{node.hostname}" do
-    rackspace_username  node['cloud_monitoring']['rackspace_username']
-    rackspace_api_key   node['cloud_monitoring']['rackspace_api_key']
-    action :create
+
+  if not node['cloud_monitoring']['rackspace_username'] or not node['cloud_monitoring']['rackspace_api_key']
+    raise RuntimeError, "agent_token variable or rackspace credentials must be set on the node."
+
+  #This runs at compile time as it needs to finish before the template for the config file fires off.
+  else
+    e = cloud_monitoring_agent_token "#{node.hostname}" do
+      rackspace_username  node['cloud_monitoring']['rackspace_username']
+      rackspace_api_key   node['cloud_monitoring']['rackspace_api_key']
+      action :nothing
+    end
+  e.run_action(:create)
+
   end
 
-  node.set['cloud_monitoring']['agent']['token'] = :token
 end
 
 package "rackspace-monitoring-agent" do

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -1,4 +1,3 @@
-
 case node['platform']
 when "ubuntu","debian"
 
@@ -47,7 +46,7 @@ if not node['cloud_monitoring']['agent']['token']
       rackspace_api_key   node['cloud_monitoring']['rackspace_api_key']
       action :nothing
     end
-  e.run_action(:create)
+    e.run_action(:create)
 
   end
 

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -36,7 +36,13 @@ rescue Exception => e
 end
 
 if not node['cloud_monitoring']['agent']['token']
-  raise RuntimeError, "agent_token variable must be set on the node."
+  cloud_monitoring_agent_token "#{node.hostname}" do
+    rackspace_username  node['cloud_monitoring']['rackspace_username']
+    rackspace_api_key   node['cloud_monitoring']['rackspace_api_key']
+    action :create
+  end
+
+  node.set['cloud_monitoring']['agent']['token'] = :token
 end
 
 package "rackspace-monitoring-agent" do

--- a/resources/agent_token.rb
+++ b/resources/agent_token.rb
@@ -5,3 +5,4 @@ attribute :token, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String

--- a/resources/alarm.rb
+++ b/resources/alarm.rb
@@ -16,3 +16,4 @@ attribute :check_label, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -17,3 +17,4 @@ attribute :entity_label, :kind_of => String
 
 attribute :rackspace_api_key, :kind_of => String
 attribute :rackspace_username, :kind_of => String
+attribute :rackspace_auth_url, :kind_of => String


### PR DESCRIPTION
This pull adds the rackspace_auth_url which fixes the rest of the issues with the auth_url not being properly filled.

It also contains a fix for the agent_token since it previously wasn't getting set before the template for the config was I applied. I also updated the docs to match the current state of the project.
