### PR TITLE
Add depends lines for Chef 11

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,5 +6,7 @@ description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.6"
 
+depends "apt", ">= 1.4.2"
 depends "python"
+depends "yum"
 


### PR DESCRIPTION
We use either apt_repository or yum_repository depending on the distro.
If for some reason a user didn't have either the apt or the yum repo in
their runlist prior to this cookbook these [would fail on Chef 11](http://docs.opscode.com/breaking_changes_chef_11.html#non-recipe-file-evaluation-includes-dependencies).

The apt depends is specifically set to the version after which
apt_repository supported cookbook_file as the key attribute.
