### PR TITLE
version bump: Update default fog to 1.16.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 default['cloud_monitoring']['rackspace_monitoring_version'] = '0.2.18'
-default['cloud_monitoring']['fog_version'] = '1.15.0'
+default['cloud_monitoring']['fog_version'] = '1.16.0'
 default['cloud_monitoring']['checks'] = {}
 default['cloud_monitoring']['alarms'] = {}
 default['cloud_monitoring']['rackspace_username'] = 'your_rackspace_username'


### PR DESCRIPTION
- 1.16.0 fixes a nasty infinite loop bug that can occur with bad
  credentials: https://github.com/fog/fog/pull/2086

This will prevent future issues like https://github.com/racker/cookbook-cloudmonitoring/issues/45
