### PR TITLE
Raise limit in api calls

### DIFF
--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -24,13 +24,13 @@ module Opscode
         )
 
         Chef::Log.debug("Opscode::Rackspace::Monitoring.cm: Loading views") if(!defined?(@@view) || @@view.nil?)
-        @@view ||= Hash[@@cm.entities.overview.map {|x| [x.identity, x]}]
+        @@view ||= Hash[@@cm.entities.overview(:limit => 500).map {|x| [x.identity, x]}]
         @@cm
       end
 
       def tokens
         Chef::Log.debug("Opscode::Rackspace::Monitoring.tokens: Loading tokens") if(!defined?(@@tokens) || @@tokens.nil?)
-        @@tokens ||= Hash[cm.agent_tokens.all.map {|x| [x.identity, x]}]
+        @@tokens ||= Hash[cm.agent_tokens.all(:limit => 500).map {|x| [x.identity, x]}]
       end
 
       def clear

--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -24,13 +24,13 @@ module Opscode
         )
 
         Chef::Log.debug("Opscode::Rackspace::Monitoring.cm: Loading views") if(!defined?(@@view) || @@view.nil?)
-        @@view ||= Hash[@@cm.entities.overview(:limit => 500).map {|x| [x.identity, x]}]
+        @@view ||= Hash[@@cm.entities.overview(:limit => 1000).map {|x| [x.identity, x]}]
         @@cm
       end
 
       def tokens
         Chef::Log.debug("Opscode::Rackspace::Monitoring.tokens: Loading tokens") if(!defined?(@@tokens) || @@tokens.nil?)
-        @@tokens ||= Hash[cm.agent_tokens.all(:limit => 500).map {|x| [x.identity, x]}]
+        @@tokens ||= Hash[cm.agent_tokens.all(:limit => 1000).map {|x| [x.identity, x]}]
       end
 
       def clear


### PR DESCRIPTION
There is currently a [bug in Rackspace Monitoring fog](https://github.com/fog/fog/issues/2469) where it fails
to handle pagination. This means if your entity is outside of the
default limit of 100 most of this cookbook will fail. It will create
duplicate entities then create duplicate checks on those entities. The
next time it runs it will do the same since the duplicate entity is also
outside the limit.
