### PR TITLE
Added existing entity support and configuration hash support

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,4 @@
+site :opscode
+
+metadata
+cookbook "yum", "~> 2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v1.1.0
+------
+* Add entity.rb to auto-select an existing entity by IP (Credit to Thomas Cate for this code)
+* Add monitors.rb to configure monitors from a configuration hash
+
 v1.0.1
 ------
 * Switch to Fog gem from rackspace-monitoring gem. Fog 1.1.15 or higher is required.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ python and python-pip (installed by this cookbook) for the raxmon-cli install
 ### General Requirements
 * You need to either set the attributes for your Rackspace username and api key in attributes/default.rb or create an encrypted data bag per the following setup steps:
 
+### Yum cookbook requirements
+
+* Due to a breaking upstream change opscode-cookbooks/yum must be below version 3.0.0.  Berkshelf version 3 will honor this, Berkshelf 2 may install the wrong version due to solver issues.
+
 ## Setup
 
 Take either step depending on your databag setup.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ python and python-pip (installed by this cookbook) for the raxmon-cli install
 
 ### Yum cookbook requirements
 
-* Due to a breaking upstream change opscode-cookbooks/yum must be below version 3.0.0.  Berkshelf version 3 will honor this, Berkshelf 2 may install the wrong version due to solver issues.
+Due to a breaking upstream change opscode-cookbooks/yum must be below version 3.0.0.
+Berkshelf version 3 will honor this, Berkshelf 2 may install the wrong version due to solver issues related to dependency cookbooks.
+To work around this on Berkshelf 2 specify
+
+```
+cookbook "yum", "~> 2.0"
+```
+
+in the Berksfile of the cookbook you're running Berkshelf against.
+
 
 ## Setup
 
@@ -100,6 +109,7 @@ The following attributes are required, either in attributes/default.rb or an enc
 This cookbook contains a "monitors" recipe that abstracts the LWRPs away behind a configuration hash.
 This recipe will handle generation of the entity, checks, and alarms.
 It will search for existing entites by IP and use them via the entity recipe.
+Please note that this recipe will always install the agent.
 
 The following example configures CPU, load, disk, and filesystem monitors, with alarms enabled on the 5 minute load average:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The following attributes are required, either in attributes/default.rb or an enc
 This cookbook contains a "monitors" recipe that abstracts the LWRPs away behind a configuration hash.
 This recipe will handle generation of the entity, checks, and alarms.
 It will search for existing entites by IP and use them via the entity recipe.
-Please note that this recipe will always install the agent.
+Please note that the cloud_monitoring::monitors recipe used in this example will always install the agent.
 
 The following example configures CPU, load, disk, and filesystem monitors, with alarms enabled on the 5 minute load average:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cloud_monitoring
 # Recipe:: default
 #
-# Copyright 2012, Rackspace
+# Copyright 2014, Rackspace
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,3 +41,25 @@ default['cloud_monitoring']['plugins']['cloud_monitoring'] = 'plugins'
 default['cloud_monitoring']['credentials']['databag_name'] = 'rackspace'
 default['cloud_monitoring']['credentials']['databag_item'] = 'cloud'
 
+# Check default values
+default['cloud_monitoring']['check_default']['period'] = 30
+default['cloud_monitoring']['check_default']['timeout'] = 10
+
+# Default main configuration hash for monitors.rb
+default['cloud_monitoring']['monitors'] = {
+  'cpu' =>  { 'type' => 'cpu', },
+  'load' => { 'type'  => 'load_average', },
+}
+# Dynamically add interface monitors
+node['network']['interfaces'].keys.each do |iface|
+  if iface != "lo"
+    default['cloud_monitoring']['monitors']["network_#{iface}"] = {
+      'type' => 'network',
+      'details' => { 'target' => iface},
+    }
+  end
+end
+# TODO: Dynamically add disks from the fstab (NOT MTAB)
+
+# TODO: Determine if there is a default notification plan and assign to it.
+# default['cloud_monitoring']['notification_plan_id'] = ???

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,9 +46,6 @@ default['cloud_monitoring']['check_default']['period'] = 30
 default['cloud_monitoring']['check_default']['timeout'] = 10
 
 # Default main configuration hash for monitors.rb
-# No checks are defined by default as there is an account-wide limit
+# No checks are defined by default as there is an account-wide limit and each check incurrs billing
 # http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/api-rsource-limits.html
 default['cloud_monitoring']['monitors'] = {}
-
-# TODO: Determine if there is a default notification plan and assign to it.
-# default['cloud_monitoring']['notification_plan_id'] = ???

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,20 +46,9 @@ default['cloud_monitoring']['check_default']['period'] = 30
 default['cloud_monitoring']['check_default']['timeout'] = 10
 
 # Default main configuration hash for monitors.rb
-default['cloud_monitoring']['monitors'] = {
-  'cpu' =>  { 'type' => 'cpu', },
-  'load' => { 'type'  => 'load_average', },
-}
-# Dynamically add interface monitors
-node['network']['interfaces'].keys.each do |iface|
-  if iface != "lo"
-    default['cloud_monitoring']['monitors']["network_#{iface}"] = {
-      'type' => 'network',
-      'details' => { 'target' => iface},
-    }
-  end
-end
-# TODO: Dynamically add disks from the fstab (NOT MTAB)
+# No checks are defined by default as there is an account-wide limit
+# http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/api-rsource-limits.html
+default['cloud_monitoring']['monitors'] = {}
 
 # TODO: Determine if there is a default notification plan and assign to it.
 # default['cloud_monitoring']['notification_plan_id'] = ???

--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -2,7 +2,22 @@ module Opscode
   module Rackspace
     module Monitoring
 
-      def cm
+      def cm(rackspace_api_key = nil, rackspace_username = nil, rackspace_auth_url = nil)
+        # This is a simple helper method to deduplicate precedence logic code
+        def attribute_logic(argument, resource, databag)
+          # Precedence:
+          # 1) Arguments
+          # 2) new_resource variables (If available)
+          # 3) Data bag
+          if argument
+            return argument
+          end
+          if resource
+            return resource
+          end
+          return databag
+        end
+
         begin
           # Access the Rackspace Cloud encrypted data_bag
           creds = Chef::EncryptedDataBagItem.load(
@@ -13,9 +28,10 @@ module Opscode
           creds = {'username' => nil, 'apikey' => nil, 'auth_url' => nil }
         end
 
-        apikey = new_resource.rackspace_api_key || creds['apikey']
-        username = new_resource.rackspace_username || creds['username']
-        auth_url = new_resource.rackspace_auth_url || creds['auth_url']
+        apikey   = attribute_logic(rackspace_api_key,  defined?(new_resource) ? new_resource.rackspace_api_key : nil,  creds['apikey'])
+        username = attribute_logic(rackspace_username, defined?(new_resource) ? new_resource.rackspace_username : nil, creds['username'])
+        auth_url = attribute_logic(rackspace_auth_url, defined?(new_resource) ? new_resource.rackspace_auth_url : nil, creds['auth_url'])
+
         Chef::Log.debug("Opscode::Rackspace::Monitoring.cm: creating new Fog connection") if(!defined?(@@cm) || @@cm.nil?)
         @@cm ||= Fog::Rackspace::Monitoring.new(
           :rackspace_api_key => apikey,

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,11 +5,11 @@ license          "Apache 2.0"
 description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          "1.0.4"
+version          "1.0.5"
 
 depends "apt", ">= 1.4.2"
 depends "python"
-depends "yum"
+depends "yum", "~> 2.0"
 depends "xml"
 
 #chef_gem cookbook/library required for chef versions <= 10.12.0

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          "Apache 2.0"
 description      "Installs/Configures Rackspace Cloud Monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          "1.0.5"
+version          "1.1.0"
 
 depends "apt", ">= 1.4.2"
 depends "python"

--- a/recipes/entity.rb
+++ b/recipes/entity.rb
@@ -19,14 +19,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'fog'
 
-service = Fog::Rackspace::Monitoring.new({
-    :rackspace_username  => node['cloud_monitoring']['rackspace_username'],
-    :rackspace_api_key   => node['cloud_monitoring']['rackspace_api_key'],
-                                         })
+# cm is defined in libraries/cloud_monitoring.rb
+class Chef::Recipe
+  include Opscode::Rackspace::Monitoring
+end
 
-response = service.list_entities.body
+cm(defined?(node['cloud_monitoring']['rackspace_api_key']) ? node['cloud_monitoring']['rackspace_api_key'] : nil,
+   defined?(node['cloud_monitoring']['rackspace_username']) ? node['cloud_monitoring']['rackspace_username'] : nil,
+   defined?(node['cloud_monitoring']['rackspace_auth_url']) ? node['cloud_monitoring']['rackspace_auth_url'] : nil)
+
+response = cm.list_entities.body
+
 
 response["values"].each do |value|
   unless value["ip_addresses"].nil?

--- a/recipes/entity.rb
+++ b/recipes/entity.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook Name:: cloud_monitoring
+# Recipe:: entity
+#
+# Configure the cloud_monitoring_entity LWRP to use the existing entity
+# for the node by matching the server IP.
+#
+# Copyright 2014, Rackspace
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'fog'
+
+service = Fog::Rackspace::Monitoring.new({
+    :rackspace_username  => node['cloud_monitoring']['rackspace_username'],
+    :rackspace_api_key   => node['cloud_monitoring']['rackspace_api_key'],
+    :rackspace_region    => node['rackspace']['region']
+                                         })
+
+response = service.list_entities.body
+
+response["values"].each do |value|
+  unless value["ip_addresses"].nil?
+    if value["ip_addresses"]["private0_v4"].eql? node["cloud"]["local_ipv4"]
+      node.set['cloud_monitoring']['label'] = value["label"]
+    end
+  end
+end
+
+if node['cloud_monitoring']['label'].nil?
+  node.set['cloud_monitoring']['label'] = node.hostname
+end
+
+cloud_monitoring_entity node['cloud_monitoring']['label'] do
+  label                 node['cloud_monitoring']['label']
+  agent_id              node['cloud_monitoring']['agent']['id']
+  rackspace_username    node['cloud_monitoring']['rackspace_username']
+  rackspace_api_key     node['cloud_monitoring']['rackspace_api_key']
+  action :create                                 
+end                                              

--- a/recipes/entity.rb
+++ b/recipes/entity.rb
@@ -24,7 +24,6 @@ require 'fog'
 service = Fog::Rackspace::Monitoring.new({
     :rackspace_username  => node['cloud_monitoring']['rackspace_username'],
     :rackspace_api_key   => node['cloud_monitoring']['rackspace_api_key'],
-    :rackspace_region    => node['rackspace']['region']
                                          })
 
 response = service.list_entities.body

--- a/recipes/entity.rb
+++ b/recipes/entity.rb
@@ -33,7 +33,7 @@ response = cm.list_entities.body
 
 
 response["values"].each do |value|
-  unless value["ip_addresses"].nil?
+  unless value["ip_addresses"].nil? || node["cloud"].nil?
     if value["ip_addresses"]["private0_v4"].eql? node["cloud"]["local_ipv4"]
       node.set['cloud_monitoring']['label'] = value["label"]
     end

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -1,0 +1,49 @@
+#
+# Cookbook Name:: cloud_monitoring
+# Recipe:: monitors
+#
+# Configure checks and alarms for Rackspace MaaS
+#
+# Copyright 2014, Rackspace
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include_recipe "cloud_monitoring::entity"
+
+node['cloud_monitoring']['monitors'].keys.sort.each do |key|
+  cloud_monitoring_check key do
+    type                  "agent.#{monitors[key]['type']}"
+    period                monitors[key].has_key?('period') ? monitors[key]['period'] : node['cloud_monitoring']['check_default']['period']
+    timeout               monitors[key].has_key?('timeout') ? monitors[key]['timeout'] : node['cloud_monitoring']['check_default']['timeout']
+    rackspace_username    node['cloud_monitoring']['rackspace_username']
+    rackspace_api_key     node['cloud_monitoring']['rackspace_api_key']
+    retries               2
+    details               monitors[key].has_key?('details') ? monitors[key]['details'] : nil
+    action :create
+  end
+  
+  if monitors[key].has_key?('alarm')
+    monitors[key]["alarm"].keys.each do |alarm|
+      # TODO: Add customizable messages, abstract the conditional more, etcetera...
+      criteria = "if (#{monitors[key]["alarm"][alarm]["conditional"]}) { return #{alarm}, '#{key} is past #{alarm} threshold' }"
+      
+      cloud_monitoring_alarm  "#{monitors[key]['type']} #{alarm} alarm" do
+        check_label           key
+        criteria              criteria
+        notification_plan_id  node['cloud_monitoring']['notification_plan_id']
+        action                :create
+      end
+
+    end # monitors[key]["alarm"] loop
+  end # if monitors[key].has_key?('alarm')
+end # monitors.keys loop

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -23,8 +23,8 @@ include_recipe "cloud_monitoring::entity"
 node['cloud_monitoring']['monitors'].each do |key, value|
   cloud_monitoring_check key do
     type                  "agent.#{value['type']}"
-    period                monitors[key].has_key?('period') ? value['period'] : node['cloud_monitoring']['check_default']['period']
-    timeout               monitors[key].has_key?('timeout') ? value['timeout'] : node['cloud_monitoring']['check_default']['timeout']
+    period                value.has_key?('period') ? value['period'] : node['cloud_monitoring']['check_default']['period']
+    timeout               value.has_key?('timeout') ? value['timeout'] : node['cloud_monitoring']['check_default']['timeout']
     rackspace_username    node['cloud_monitoring']['rackspace_username']
     rackspace_api_key     node['cloud_monitoring']['rackspace_api_key']
     retries               2

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -18,6 +18,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Include dependency recipes
+include_recipe "cloud_monitoring"
+include_recipe "cloud_monitoring::agent"
 include_recipe "cloud_monitoring::entity"
 
 node['cloud_monitoring']['monitors'].each do |key, value|

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -20,30 +20,30 @@
 #
 include_recipe "cloud_monitoring::entity"
 
-node['cloud_monitoring']['monitors'].keys.sort.each do |key|
+node['cloud_monitoring']['monitors'].each do |key, value|
   cloud_monitoring_check key do
-    type                  "agent.#{monitors[key]['type']}"
-    period                monitors[key].has_key?('period') ? monitors[key]['period'] : node['cloud_monitoring']['check_default']['period']
-    timeout               monitors[key].has_key?('timeout') ? monitors[key]['timeout'] : node['cloud_monitoring']['check_default']['timeout']
+    type                  "agent.#{value['type']}"
+    period                monitors[key].has_key?('period') ? value['period'] : node['cloud_monitoring']['check_default']['period']
+    timeout               monitors[key].has_key?('timeout') ? value['timeout'] : node['cloud_monitoring']['check_default']['timeout']
     rackspace_username    node['cloud_monitoring']['rackspace_username']
     rackspace_api_key     node['cloud_monitoring']['rackspace_api_key']
     retries               2
-    details               monitors[key].has_key?('details') ? monitors[key]['details'] : nil
+    details               value.has_key?('details') ? value['details'] : nil
     action :create
   end
   
-  if monitors[key].has_key?('alarm')
-    monitors[key]["alarm"].keys.each do |alarm|
+  if value.has_key?('alarm')
+    value["alarm"].each do |alarm, alarm_value|
       # TODO: Add customizable messages, abstract the conditional more, etcetera...
-      criteria = "if (#{monitors[key]["alarm"][alarm]["conditional"]}) { return #{alarm}, '#{key} is past #{alarm} threshold' }"
+      criteria = "if (#{alarm_value["conditional"]}) { return #{alarm}, '#{key} is past #{alarm} threshold' }"
       
-      cloud_monitoring_alarm  "#{monitors[key]['type']} #{alarm} alarm" do
+      cloud_monitoring_alarm  "#{value['type']} #{alarm} alarm" do
         check_label           key
         criteria              criteria
         notification_plan_id  node['cloud_monitoring']['notification_plan_id']
         action                :create
       end
 
-    end # monitors[key]["alarm"] loop
-  end # if monitors[key].has_key?('alarm')
-end # monitors.keys loop
+    end # alarm loop
+  end # has_key?('alarm')
+end # monitors loop


### PR DESCRIPTION
Added recipes to reuse existing entities and to allow configuration via a configuration hash.  No breaking changes made.  Includes the yum version pin from pull request #51.
