### PR TITLE
Request 1000 entities when fetching overview

### DIFF
--- a/libraries/cloud_monitoring.rb
+++ b/libraries/cloud_monitoring.rb
@@ -24,7 +24,7 @@ module Opscode
         )
 
         Chef::Log.debug("Opscode::Rackspace::Monitoring.cm: Loading views") if(!defined?(@@view) || @@view.nil?)
-        @@view ||= Hash[@@cm.entities.overview.map {|x| [x.identity, x]}]
+        @@view ||= Hash[@@cm.entities.overview({ 'limit' => 1000 }).map {|x| [x.identity, x]}]
         @@cm
       end
 


### PR DESCRIPTION
The default overview pagination limit is 100.  On accounts with
more than 100 entities, the cookbook will improperly identify which
entities already exist and which do not, which will cause errors
when attempting to use the cloud_monitoring_entity.
