### PR TITLE
Pin Yum cookbook dependency to < 3.0.0, so that things don't break.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          "1.0.4"
 
 depends "apt", ">= 1.4.2"
 depends "python"
-depends "yum"
+depends "yum", "< 3.0.0"
 depends "xml"
 
 #chef_gem cookbook/library required for chef versions <= 10.12.0


### PR DESCRIPTION
Since there seems to not be a good way in Chef to search Cookbook versions, grab the result and do something with them, this is the next best workaround to that issue given we're still reliant on Yum-2.x.
