### PR TITLE
Added ChefSpec matcher file for providers

### DIFF
--- a/libraries/matcher.rb
+++ b/libraries/matcher.rb
@@ -1,0 +1,26 @@
+if defined?(ChefSpec)
+    def create_cm_agent_token(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:cloud_monitoring_agent_token, :create, resource_name)
+    end
+
+    def delete_cm_agent_token(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:cloud_monitoring_agent_token, :delete, resource_name)
+    end
+
+    def create_cm_alarm(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:cloud_monitoring_alarm, :create, resource_name)
+    end
+
+    def create_cm_check(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:cloud_monitoring_check, :create, resource_name)
+    end
+
+    def create_cm_entity(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:cloud_monitoring_entity, :create, resource_name)
+    end
+
+    def delete_cm_entity(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:cloud_monitoring_entity, :delete, resource_name)
+    end
+end
+


### PR DESCRIPTION
Added [ChefSpec](https://github.com/sethvargo/chefspec) matchers for all the current providers. This allows you to test the providers directly.

``` Ruby
it 'creates a nginx service check' do
  expect(chef_run).to create_cm_check('nginx service')
end
```
