### PR TITLE
Fix bug where agent token is destroyed every run

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -47,7 +47,7 @@ begin
 
   values = Chef::EncryptedDataBagItem.load(databag_dir, databag_filename)
 
-  node.set['cloud_monitoring']['agent']['token'] = values['agent_token'] || nil
+  node.set['cloud_monitoring']['agent']['token'] = values['agent_token'] if values.to_hash.has_key? 'agent_token'
 rescue Exception => e
   Chef::Log.error 'Failed to load rackspace cloud data bag: ' + e.to_s
 end


### PR DESCRIPTION
If the data bag doesn't contain a token named 'agent_token' then the node attribute is set to nil. This wipes out previously generated agent tokens.
