### PR TITLE
Added the monitoring_id to rackspace-monitoring-agent.cfg.

### DIFF
--- a/templates/default/rackspace-monitoring-agent.erb
+++ b/templates/default/rackspace-monitoring-agent.erb
@@ -1,3 +1,6 @@
+<% if @monitoring_id != nil %>
+monitoring_id <%= @monitoring_id %>
+<% end %>
 monitoring_token <%= @monitoring_token %>
 <% if not node['cloud_monitoring']['monitoring_endpoints'].empty? %>
 monitoring_endpoints <%= node['cloud_monitoring']['monitoring_endpoints'].join(",") %>


### PR DESCRIPTION
Removing this caused the monitoring agent to be unable to connect to the API.

From our logs:

```
Wed Dec 17 18:21:04 2014 ERR: Confd -> Not sending config files because agent is not bound to an entity
```
